### PR TITLE
docs: simplify installation instructions with auto-detection variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Download the binary for your platform from the [release page](https://github.com
 
 **AMD64 (x86_64):**
 ```bash
-sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.11/slack_v0.0.11_linux_amd64
+sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.13/slack_v0.0.13_linux_amd64
 sudo chmod +x /usr/local/bin/slack
 ```
 
 **ARM64:**
 ```bash
-sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.11/slack_v0.0.11_linux_arm64
+sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.13/slack_v0.0.13_linux_arm64
 sudo chmod +x /usr/local/bin/slack
 ```
 
@@ -28,13 +28,13 @@ sudo chmod +x /usr/local/bin/slack
 
 **Intel (AMD64):**
 ```bash
-sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.11/slack_v0.0.11_darwin_amd64
+sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.13/slack_v0.0.13_darwin_amd64
 sudo chmod +x /usr/local/bin/slack
 ```
 
 **Apple Silicon (ARM64):**
 ```bash
-sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.11/slack_v0.0.11_darwin_arm64
+sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.13/slack_v0.0.13_darwin_arm64
 sudo chmod +x /usr/local/bin/slack
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,31 +10,11 @@ It's aimed at coding agents with a very simple interface, and is not intended to
 
 Download the binary for your platform from the [release page](https://github.com/kitproj/slack-cli/releases).
 
-### Linux
-
-**AMD64 (x86_64):**
 ```bash
-sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.13/slack_v0.0.13_linux_amd64
-sudo chmod +x /usr/local/bin/slack
-```
-
-**ARM64:**
-```bash
-sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.13/slack_v0.0.13_linux_arm64
-sudo chmod +x /usr/local/bin/slack
-```
-
-### MacOS
-
-**Intel (AMD64):**
-```bash
-sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.13/slack_v0.0.13_darwin_amd64
-sudo chmod +x /usr/local/bin/slack
-```
-
-**Apple Silicon (ARM64):**
-```bash
-sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/v0.0.13/slack_v0.0.13_darwin_arm64
+VERSION=v0.0.13
+PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+sudo curl -fsL -o /usr/local/bin/slack https://github.com/kitproj/slack-cli/releases/download/${VERSION}/slack_${VERSION}_${PLATFORM}_${ARCH}
 sudo chmod +x /usr/local/bin/slack
 ```
 


### PR DESCRIPTION
Simplifies the installation instructions in the README by using shell variables to automatically detect platform and architecture.

**Changes:**
- Replaced four separate installation sections (Linux AMD64, Linux ARM64, MacOS Intel, MacOS Apple Silicon) with a single unified installation script
- Uses `uname -s` to auto-detect platform (linux/darwin)
- Uses `uname -m` to auto-detect architecture (amd64/arm64)
- Easier to maintain - only VERSION variable needs updating for new releases

The new installation method works across all supported platforms and architectures.